### PR TITLE
20231106-1 - Add /register Route and Register module

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "dev": "ng serve --host 0.0.0.0 --disable-host-check",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test --code-coverage",
-    "test:watch": "ng test --watch --code-coverage",
+    "test": "ng test --code-coverage --browsers=ChromeHeadless",
+    "test:watch": "ng test --watch --code-coverage --browsers=ChromeHeadless",
     "cci:install": "sh scripts/cci-npm-install.sh",
     "cci:test": "sh scripts/cci-npm-test.sh"
   },

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,4 @@
+<h1 class="content">
+  <span> {{ title }} </span>
+</h1>
 <router-outlet></router-outlet>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -3,10 +3,12 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    imports: [RouterTestingModule],
-    declarations: [AppComponent]
-  }));
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [AppComponent],
+    })
+  );
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
@@ -24,6 +26,8 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('.content span')?.textContent).toContain('not-crm app is running!');
+    expect(compiled.querySelector('.content span')?.textContent).toContain(
+      'not-crm'
+    );
   });
 });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,12 +2,14 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { AppRoutingModule } from './app-routing.module';
-import { AppComponent } from './app.component';
+import { SharedModule } from './shared/shared.module';
 import { RegisterModule } from './features/register/register.module';
+
+import { AppComponent } from './app.component';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, AppRoutingModule, RegisterModule],
+  imports: [BrowserModule, AppRoutingModule, SharedModule, RegisterModule],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/src/app/features/register/register.component.html
+++ b/src/app/features/register/register.component.html
@@ -1,1 +1,57 @@
-<p>register works!</p>
+<main>
+  <fieldset>
+    <app-input-field
+      [labelFor]="'username'"
+      [labelClassName]="'label-username'"
+      [labelText]="'Username'"
+      [inputType]="'text'"
+      [inputId]="'input-username'"
+      [inputName]="'username'"
+      [inputPlaceholder]="'e.g. tango123'"
+      [inputClassName]="'input-username'"
+      (inputChange)="onChange($event)"
+    >
+    </app-input-field>
+
+    <app-input-field
+      [labelFor]="'email'"
+      [labelClassName]="'label-email'"
+      [labelText]="'Email'"
+      [inputType]="'email'"
+      [inputId]="'input-email'"
+      [inputName]="'email'"
+      [inputPlaceholder]="'e.g. monster.cookie@sesame-street.com'"
+      [inputClassName]="'input-email'"
+      (inputChange)="onChange($event)"
+    >
+    </app-input-field>
+
+    <app-input-field
+      [labelFor]="'password'"
+      [labelClassName]="'label-password'"
+      [labelText]="'Password'"
+      [inputType]="'password'"
+      [inputId]="'input-password'"
+      [inputName]="'password'"
+      [inputPlaceholder]="'e.g. Password123#'"
+      [inputClassName]="'input-password'"
+      (inputChange)="onChange($event)"
+    >
+    </app-input-field>
+
+    <app-input-field
+      [labelFor]="'confirmPassword'"
+      [labelClassName]="'input-confirm-password'"
+      [labelText]="'Confirm password'"
+      [inputType]="'password'"
+      [inputId]="'input-confirm-password'"
+      [inputName]="'confirmPassword'"
+      [inputPlaceholder]="'e.g. Password123#'"
+      [inputClassName]="'input-confirm-password'"
+      (inputChange)="onChange($event)"
+    >
+    </app-input-field>
+
+    <a role="link" (click)="onClick()"> Register </a>
+  </fieldset>
+</main>

--- a/src/app/features/register/register.component.scss
+++ b/src/app/features/register/register.component.scss
@@ -1,0 +1,22 @@
+* {
+  font-size: min(4rem, max(.875rem, 2vw))
+}
+
+main {
+  display: flex;
+  justify-content: center
+}
+
+fieldset {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  width: fit-content
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/src/app/features/register/register.component.spec.ts
+++ b/src/app/features/register/register.component.spec.ts
@@ -21,5 +21,36 @@ describe('RegisterComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render', () => {});
+  it('should have the email updated when .onChange() got called with an object that has id = "email"', () => {
+    const inputEvent = {
+      id: 'email',
+      value: 'test@email.com',
+    };
+    component.onChange(inputEvent);
+    fixture.detectChanges();
+
+    expect(component.email).toEqual(inputEvent.value);
+  });
+
+  it('should have the password updated when .onChange() got called with an object that has id = "password"', () => {
+    const inputEvent = {
+      id: 'password',
+      value: 'test@password',
+    };
+    component.onChange(inputEvent);
+    fixture.detectChanges();
+
+    expect(component.email).toEqual(inputEvent.value);
+  });
+
+  it('should have the confirmPassword updated when .onChange() got called with an object that has id = "confirmPassword"', () => {
+    const inputEvent = {
+      id: 'confirmPassword',
+      value: 'test@password',
+    };
+    component.onChange(inputEvent);
+    fixture.detectChanges();
+
+    expect(component.email).toEqual(inputEvent.value);
+  });
 });

--- a/src/app/features/register/register.component.spec.ts
+++ b/src/app/features/register/register.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { RegisterComponent } from './register.component';
 
@@ -8,7 +9,8 @@ describe('RegisterComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [RegisterComponent]
+      declarations: [RegisterComponent],
+      schemas: [NO_ERRORS_SCHEMA],
     });
     fixture = TestBed.createComponent(RegisterComponent);
     component = fixture.componentInstance;
@@ -18,4 +20,6 @@ describe('RegisterComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should render', () => {});
 });

--- a/src/app/features/register/register.component.ts
+++ b/src/app/features/register/register.component.ts
@@ -1,10 +1,34 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+
+import { InputFieldEvent } from 'src/app/shared/shared.interfaces';
 
 @Component({
   selector: 'app-register',
   templateUrl: './register.component.html',
-  styleUrls: ['./register.component.scss']
+  styleUrls: ['./register.component.scss'],
 })
 export class RegisterComponent {
+  public email: string = '';
+  public password: string = '';
+  public confirmPassword: string = '';
 
+  public onChange(event: InputFieldEvent): void {
+    const { id, value } = event;
+
+    switch (id) {
+      case 'email':
+        this.email = value;
+        break;
+      case 'password':
+        this.password = value;
+        break;
+      case 'confirmPassword':
+        this.confirmPassword = value;
+        break;
+    }
+  }
+
+  public onClick(): void {
+    console.log('onClick()');
+  }
 }

--- a/src/app/features/register/register.module.ts
+++ b/src/app/features/register/register.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
+import { SharedModule } from 'src/app/shared/shared.module';
+
 import { RegisterComponent } from './register.component';
 
 @NgModule({
   declarations: [RegisterComponent],
-  imports: [CommonModule],
+  imports: [CommonModule, SharedModule],
 })
 export class RegisterModule {}

--- a/src/app/shared/input-field.component/input-field.component.spec.ts
+++ b/src/app/shared/input-field.component/input-field.component.spec.ts
@@ -4,7 +4,7 @@ import { DebugElement } from '@angular/core';
 
 import { InputFieldComponent } from './input-field.component';
 
-fdescribe('InputFieldComponent', () => {
+describe('InputFieldComponent', () => {
   let component: InputFieldComponent;
   let fixture: ComponentFixture<InputFieldComponent>;
 


### PR DESCRIPTION
Implementations:

- Added headless browser implementation on unit testing;
- Adjust app.component's unit testing. Temporary;
- Added Register component that uses input-field component reusable;
- Wrapped Register component as a module;
- Removed 'fdescribe' from input-field.component.spec.ts.