### PR TITLE
Feature/20231127-1 - Update Register Form, Error Handling, Proxy Config

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -56,6 +56,10 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "notCrm:build",
+            "proxyConfig": "src/proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "browserTarget": "not-crm:build:production"

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test --code-coverage --browsers=ChromeHeadless",
     "test:watch": "ng test --watch --code-coverage --browsers=ChromeHeadless",
+    "test:view:coverage": "open ./coverage/not-crm/index.html",
     "cci:install": "sh scripts/cci-npm-install.sh",
     "cci:test": "sh scripts/cci-npm-test.sh",
     "ci:test": "npx ng test --project not-crm --no-watch --no-progress --code-coverage --browsers=ChromeHeadless",
     "lint": "ng lint",
-    "github/super-linter": "sh scripts/github-super-linter.sh"
+    "github/super-linter": "sh scripts/github-super-linter.sh",
+    "ci:build:prod": "ng build —prod —output-hashing name"
   },
   "private": true,
   "dependencies": {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -12,6 +12,11 @@ const routes: Routes = [
         (m) => m.RegisterModule
       ),
   },
+  {
+    // temporary, will be replaced when login module has been developed
+    path: 'login',
+    redirectTo: '/',
+  },
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
 
 import { AppRoutingModule } from './app-routing.module';
 import { SharedModule } from './shared/shared.module';
@@ -16,6 +17,7 @@ import { CommonModule } from '@angular/common';
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
+    HttpClientModule,
     AppRoutingModule,
     SharedModule,
     RegisterModule,

--- a/src/app/features/register/register-http.service.spec.ts
+++ b/src/app/features/register/register-http.service.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { HttpClient, HttpHandler } from '@angular/common/http';
+
+import { RegisterHttpService } from './register-http.service';
+
+describe('RegisterHttpService', () => {
+  let httpHandler: HttpHandler;
+  let httpClient: HttpClient;
+  let registerHttpService: RegisterHttpService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: RegisterHttpService, useClass: RegisterHttpService },
+        HttpClient,
+        HttpHandler,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    });
+    httpHandler = TestBed.inject(HttpHandler);
+    httpClient = TestBed.inject(HttpClient);
+    registerHttpService = TestBed.inject(RegisterHttpService);
+  });
+
+  it('should create', () => {
+    expect(registerHttpService).toBeTruthy();
+  });
+
+  it('should call RegisterHttpService method on register and redirect to /login on success response', async () => {
+    const form = {
+      email: 'username@email.com',
+      username: 'username-email-com',
+      password: 'somerandompassword',
+      role: 'user',
+    };
+    spyOn(httpClient, 'post');
+
+    registerHttpService.register(form);
+
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/features/register/register-http.service.spec.ts
+++ b/src/app/features/register/register-http.service.spec.ts
@@ -5,6 +5,7 @@ import { HttpClient, HttpHandler } from '@angular/common/http';
 import { RegisterHttpService } from './register-http.service';
 
 describe('RegisterHttpService', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let httpHandler: HttpHandler;
   let httpClient: HttpClient;
   let registerHttpService: RegisterHttpService;

--- a/src/app/features/register/register-http.service.ts
+++ b/src/app/features/register/register-http.service.ts
@@ -8,7 +8,7 @@ import { RegisterDTO, ApiResponseDTO } from './register.interface';
   providedIn: 'any',
 })
 export class RegisterHttpService {
-  private path = '/api/v1/account/register'; // '/api/v1/account';
+  private path = '/api/v1/account/register';
 
   constructor(private readonly http: HttpClient) {}
 
@@ -16,7 +16,6 @@ export class RegisterHttpService {
     const httpOptions = {
       headers: new HttpHeaders({
         'Content-Type': 'application/json',
-        // Authorization: 'my-auth-token'
       }),
     };
 
@@ -29,11 +28,3 @@ export class RegisterHttpService {
     return result$;
   }
 }
-// const result$ = this.http.get(this.path);
-// result$.subscribe((val) => console.log(19, val));
-// return result$;
-
-/* set header because httpOptions is immutable
-        httpOptions.headers =
-        httpOptions.headers.set('Authorization', 'my-new-auth-token');
-    */

--- a/src/app/features/register/register-http.service.ts
+++ b/src/app/features/register/register-http.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { RegisterDTO, ApiResponseDTO } from './register.interface';
+
+@Injectable({
+  providedIn: 'any',
+})
+export class RegisterHttpService {
+  private path = '/api/v1/account/register'; // '/api/v1/account';
+
+  constructor(private readonly http: HttpClient) {}
+
+  public register(form: RegisterDTO): Observable<ApiResponseDTO> {
+    const httpOptions = {
+      headers: new HttpHeaders({
+        'Content-Type': 'application/json',
+        // Authorization: 'my-auth-token'
+      }),
+    };
+
+    const result$ = this.http.post<ApiResponseDTO>(
+      this.path,
+      form,
+      httpOptions
+    );
+
+    return result$;
+  }
+}
+// const result$ = this.http.get(this.path);
+// result$.subscribe((val) => console.log(19, val));
+// return result$;
+
+/* set header because httpOptions is immutable
+        httpOptions.headers =
+        httpOptions.headers.set('Authorization', 'my-new-auth-token');
+    */

--- a/src/app/features/register/register.component.html
+++ b/src/app/features/register/register.component.html
@@ -1,51 +1,65 @@
-<fieldset>
-  <form [formGroup]="register" (ngSubmit)="onSubmit()" id="registerForm">
+<form [formGroup]="register" (ngSubmit)="onSubmit()" id="registerForm">
+  <fieldset>
+    <legend>Register Form</legend>
     <div class="label-input">
-      <div>
-        <label id="label-email" for="input-email"> Email: </label>
+      <input
+        id="input-email"
+        type="text"
+        formControlName="email"
+        placeholder="e.g: someone@email.com"
+        required
+      />
+      <div class="label-error-wrapper">
+        <label id="label-email" for="input-email"> Email.</label>
         <span role="alert" class="error">
           {{ email?.errors | errorsMessagePipe: errorMessages.email }}
         </span>
       </div>
-      <input id="input-email" type="text" formControlName="email" required />
     </div>
 
     <div class="label-input">
-      <div>
-        <label id="label-username" for="input-username"> Username: </label>
-        <span role="alert" class="error">
-          {{ username?.errors | errorsMessagePipe: errorMessages.username }}
-        </span>
-      </div>
-
       <input
         id="input-username"
         type="email"
         formControlName="username"
+        placeholder="e.g: user_name-888"
         required
       />
+      <div class="label-error-wrapper">
+        <label id="label-username" for="input-username"> Username. </label>
+        <span role="alert" class="error">
+          {{ username?.errors | errorsMessagePipe: errorMessages.username }}
+        </span>
+      </div>
     </div>
 
     <div class="label-input">
-      <div>
-        <label id="label-password" for="input-password"> Password: </label>
-        <span role="alert" class="error">
-          {{ password?.errors | errorsMessagePipe: errorMessages.password }}
-        </span>
-      </div>
-
       <input
         id="input-password"
         type="password"
         formControlName="password"
+        placeholder="e.g: Password123"
         required
       />
+      <div class="label-error-wrapper">
+        <label id="label-password" for="input-password"> Password. </label>
+        <span role="alert" class="error">
+          {{ password?.errors | errorsMessagePipe: errorMessages.password }}
+        </span>
+      </div>
     </div>
 
     <div class="label-input">
-      <div>
+      <input
+        id="input-confirmPassword"
+        type="password"
+        formControlName="confirmPassword"
+        placeholder="e.g: Password123"
+        required
+      />
+      <div class="label-error-wrapper">
         <label id="label-confirmPassword" for="input-confirmPassword">
-          Password confirmation:
+          Password confirmation.
         </label>
         <span role="alert" class="error">
           {{
@@ -74,13 +88,6 @@
           }}
         </span>
       </div>
-
-      <input
-        id="input-confirmPassword"
-        type="password"
-        formControlName="confirmPassword"
-        required
-      />
     </div>
 
     <div>
@@ -98,5 +105,5 @@
         Register
       </button>
     </div>
-  </form>
-</fieldset>
+  </fieldset>
+</form>

--- a/src/app/features/register/register.component.html
+++ b/src/app/features/register/register.component.html
@@ -1,34 +1,18 @@
-<form [formGroup]="register" (ngSubmit)="onSubmit()" id="registerForm">
+<form (ngSubmit)="onSubmit()" id="registerForm">
   <fieldset>
     <legend>Register Form</legend>
     <div class="label-input">
       <input
         id="input-email"
         type="text"
-        formControlName="email"
+        [formControl]="email"
         placeholder="e.g: someone@email.com"
         required
       />
       <div class="label-error-wrapper">
         <label id="label-email" for="input-email"> Email.</label>
         <span role="alert" class="error">
-          {{ email?.errors | errorsMessagePipe: errorMessages.email }}
-        </span>
-      </div>
-    </div>
-
-    <div class="label-input">
-      <input
-        id="input-username"
-        type="email"
-        formControlName="username"
-        placeholder="e.g: user_name-888"
-        required
-      />
-      <div class="label-error-wrapper">
-        <label id="label-username" for="input-username"> Username. </label>
-        <span role="alert" class="error">
-          {{ username?.errors | errorsMessagePipe: errorMessages.username }}
+          {{ email.errors | errorsMessagePipe: errorMessages.email }}
         </span>
       </div>
     </div>
@@ -37,14 +21,14 @@
       <input
         id="input-password"
         type="password"
-        formControlName="password"
+        [formControl]="password"
         placeholder="e.g: Password123"
         required
       />
       <div class="label-error-wrapper">
         <label id="label-password" for="input-password"> Password. </label>
         <span role="alert" class="error">
-          {{ password?.errors | errorsMessagePipe: errorMessages.password }}
+          {{ password.errors | errorsMessagePipe: errorMessages.password }}
         </span>
       </div>
     </div>
@@ -53,7 +37,7 @@
       <input
         id="input-confirmPassword"
         type="password"
-        formControlName="confirmPassword"
+        [formControl]="confirmPassword"
         placeholder="e.g: Password123"
         required
       />
@@ -63,7 +47,7 @@
         </label>
         <span role="alert" class="error">
           {{
-            confirmPassword?.errors
+            confirmPassword.errors
               | errorsMessagePipe: errorMessages.confirmPassword
           }}
         </span>
@@ -71,20 +55,20 @@
           role="alert"
           [class.error]="
             (
-              confirmPassword?.errors
-              | confirmPasswordPipe: password?.value : confirmPassword?.value
+              confirmPassword.errors
+              | confirmPasswordPipe: password.value : confirmPassword.value
             ).includes('not confirmed')
           "
           [class.ok]="
             !(
-              confirmPassword?.errors
-              | confirmPasswordPipe: password?.value : confirmPassword?.value
+              confirmPassword.errors
+              | confirmPasswordPipe: password.value : confirmPassword.value
             ).includes('not confirmed')
           "
         >
           {{
-            confirmPassword?.errors
-              | confirmPasswordPipe: password?.value : confirmPassword?.value
+            confirmPassword.errors
+              | confirmPasswordPipe: password.value : confirmPassword.value
           }}
         </span>
       </div>
@@ -94,16 +78,15 @@
       <button
         type="submit"
         [disabled]="
-          !register.valid ||
-          email?.errors ||
-          username?.errors ||
-          password?.errors ||
-          confirmPassword?.errors ||
-          password?.value !== confirmPassword?.value
+          email.errors ||
+          password.errors ||
+          confirmPassword.errors ||
+          password.value !== confirmPassword.value
         "
       >
         Register
       </button>
+      <span class="error">{{ loginFail }}</span>
     </div>
   </fieldset>
 </form>

--- a/src/app/features/register/register.component.scss
+++ b/src/app/features/register/register.component.scss
@@ -6,14 +6,19 @@ span.ok {
   color: green;
 }
 
-form {
+div.label-error-wrapper {
+  height: 2.5em;
+}
+
+fieldset {
+  padding: 2.5em;
   width: 55%;
   display: flex;
   flex-direction: column;
   row-gap: 1em;
 }
 
-fieldset {
+form {
   display: flex;
   justify-content: center;
   border: none;
@@ -21,6 +26,10 @@ fieldset {
 
 input {
   width: 100%;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  height: 2em;
 }
 
 .label-input {

--- a/src/app/features/register/register.component.spec.ts
+++ b/src/app/features/register/register.component.spec.ts
@@ -1,20 +1,34 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Router } from '@angular/router';
+import { HttpClient, HttpHandler } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
 
 import { RegisterComponent } from './register.component';
 import { ErrorsMessagePipe } from 'src/app/shared/pipes/errors-message.pipe';
 import { SharedModule } from 'src/app/shared/shared.module';
+import { RegisterHttpService } from './register-http.service';
 
 describe('RegisterComponent', () => {
   let component: RegisterComponent;
   let fixture: ComponentFixture<RegisterComponent>;
+  let router: Router;
+  let registerHttpService: RegisterHttpService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [RegisterComponent, ErrorsMessagePipe],
       imports: [SharedModule],
+      providers: [
+        { provide: RegisterHttpService, useClass: RegisterHttpService },
+        { provide: Router, useClass: Router },
+        HttpClient,
+        HttpHandler,
+      ],
       schemas: [NO_ERRORS_SCHEMA],
     });
+    registerHttpService = TestBed.inject(RegisterHttpService);
+    router = TestBed.inject(Router);
     fixture = TestBed.createComponent(RegisterComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -22,5 +36,50 @@ describe('RegisterComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call RegisterHttpService method on register and redirect to /login on success response', async () => {
+    const email = 'username@email.com';
+    const password = 'somerandompassword';
+    component.email.setValue(email);
+    component.password.setValue(password);
+
+    spyOn(registerHttpService, 'register').and.returnValues(
+      of({
+        ok: true,
+        status: 201,
+        message: 'account created',
+        result: { id: 1 },
+      })
+    );
+    spyOn(router, 'navigate').and.callFake(async () => true);
+
+    component.onSubmit();
+
+    expect(registerHttpService.register).toHaveBeenCalledWith({
+      email,
+      password,
+      username: 'username-email-com',
+      role: 'user',
+    });
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+
+  it('should call RegisterHttpService method on register and show email exists message when getting 409 Conflict error response', () => {
+    const email = 'username@email.com';
+    const password = 'somerandompassword';
+    component.email.setValue(email);
+    component.password.setValue(password);
+
+    spyOn(registerHttpService, 'register').and.returnValue(
+      throwError(
+        new Error(
+          'Http failure response for http://localhost:4200/api/v1/account/register: 409 Conflict'
+        )
+      )
+    );
+    component.onSubmit();
+
+    expect(component.loginFail).toBeTruthy();
   });
 });

--- a/src/app/features/register/register.component.ts
+++ b/src/app/features/register/register.component.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { take } from 'rxjs';
 
 import { length, valid, errorMessages } from '../../shared/constants';
 import { RegisterHttpService } from './register-http.service';
@@ -13,8 +15,12 @@ const { required, minLength, maxLength, pattern } = Validators;
 })
 export class RegisterComponent {
   public errorMessages = errorMessages;
+  public loginFail = '';
 
-  constructor(private http: RegisterHttpService) {}
+  constructor(
+    private http: RegisterHttpService,
+    private router: Router
+  ) {}
 
   public register = new FormGroup({
     email: new FormControl('', [
@@ -52,8 +58,15 @@ export class RegisterComponent {
       role: 'user',
     };
 
-    console.log(form);
-    this.http.register(form);
+    this.http
+      .register(form)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.router.navigate(['/login']);
+        },
+        error: (error: Error) => console.log(error),
+      });
   }
 
   get email() {

--- a/src/app/features/register/register.component.ts
+++ b/src/app/features/register/register.component.ts
@@ -1,7 +1,7 @@
-import { Component } from '@angular/core';
-import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { Component, OnDestroy } from '@angular/core';
+import { FormControl, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
-import { take } from 'rxjs';
+import { Subscription, take } from 'rxjs';
 
 import { length, valid, errorMessages } from '../../shared/constants';
 import { RegisterHttpService } from './register-http.service';
@@ -13,43 +13,39 @@ const { required, minLength, maxLength, pattern } = Validators;
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.scss'],
 })
-export class RegisterComponent {
+export class RegisterComponent implements OnDestroy {
   public errorMessages = errorMessages;
-  public loginFail = '';
+  loginFail = '';
+  private subscription$: Subscription | null = null;
 
   constructor(
-    private http: RegisterHttpService,
+    private registerHttpService: RegisterHttpService,
     private router: Router
   ) {}
 
-  public register = new FormGroup({
-    email: new FormControl('', [
-      required,
-      minLength(length.email.min),
-      maxLength(length.email.max),
-      pattern(valid.email),
-    ]),
-    username: new FormControl('', [
-      required,
-      minLength(length.username.min),
-      maxLength(length.username.max),
-      pattern(valid.username),
-    ]),
-    role: new FormControl({ value: 'user', disabled: true }),
-    password: new FormControl('', [
-      required,
-      minLength(length.password.min),
-      pattern(valid.password),
-    ]),
-    confirmPassword: new FormControl('', [required]),
-  });
+  public email = new FormControl<string | null>('', [
+    required,
+    minLength(length.email.min),
+    maxLength(length.email.max),
+    pattern(valid.email),
+  ]);
+  public password = new FormControl<string | null>('', [
+    required,
+    minLength(length.password.min),
+    pattern(valid.password),
+  ]);
+  public confirmPassword = new FormControl<string | null>('', [required]);
+
+  ngOnDestroy(): void {
+    this.subscription$?.unsubscribe();
+  }
 
   public onSubmit(): void {
-    const { username, email, password } = this.register.value;
+    const email = this.email.value || '';
+    const password = this.password.value || '';
 
-    if (!username || !email || !password) {
-      return;
-    }
+    const regex = /[@\.]/gi;
+    const username = email.replace(regex, '-');
 
     const form = {
       email,
@@ -58,30 +54,21 @@ export class RegisterComponent {
       role: 'user',
     };
 
-    this.http
+    this.registerHttpService
       .register(form)
       .pipe(take(1))
       .subscribe({
         next: () => {
           this.router.navigate(['/login']);
         },
-        error: (error: Error) => console.log(error),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        error: (error: any) => {
+          if (error.message.indexOf('409 Conflict')) {
+            this.loginFail = 'email exists';
+          } else {
+            this.loginFail = 'something is wrong';
+          }
+        },
       });
-  }
-
-  get email() {
-    return this.register.get('email');
-  }
-
-  get username() {
-    return this.register.get('username');
-  }
-
-  get password() {
-    return this.register.get('password');
-  }
-
-  get confirmPassword() {
-    return this.register.get('confirmPassword');
   }
 }

--- a/src/app/features/register/register.component.ts
+++ b/src/app/features/register/register.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 
 import { length, valid, errorMessages } from '../../shared/constants';
+import { RegisterHttpService } from './register-http.service';
 
 const { required, minLength, maxLength, pattern } = Validators;
 
@@ -12,6 +13,8 @@ const { required, minLength, maxLength, pattern } = Validators;
 })
 export class RegisterComponent {
   public errorMessages = errorMessages;
+
+  constructor(private http: RegisterHttpService) {}
 
   public register = new FormGroup({
     email: new FormControl('', [
@@ -36,7 +39,21 @@ export class RegisterComponent {
   });
 
   public onSubmit(): void {
-    console.log(this.register.value);
+    const { username, email, password } = this.register.value;
+
+    if (!username || !email || !password) {
+      return;
+    }
+
+    const form = {
+      email,
+      username,
+      password,
+      role: 'user',
+    };
+
+    console.log(form);
+    this.http.register(form);
   }
 
   get email() {

--- a/src/app/features/register/register.component.ts
+++ b/src/app/features/register/register.component.ts
@@ -44,7 +44,7 @@ export class RegisterComponent implements OnDestroy {
     const email = this.email.value || '';
     const password = this.password.value || '';
 
-    const regex = /[@\.]/gi;
+    const regex = /[@.]/gi;
     const username = email.replace(regex, '-');
 
     const form = {

--- a/src/app/features/register/register.interface.ts
+++ b/src/app/features/register/register.interface.ts
@@ -1,0 +1,17 @@
+export interface RegisterDTO {
+  email: string;
+  username: string;
+  role: string;
+  password: string;
+}
+
+interface AccountId {
+  id: number;
+}
+
+export interface ApiResponseDTO {
+  status: string;
+  ok: boolean;
+  result: AccountId | null;
+  message: string;
+}

--- a/src/app/features/register/register.interface.ts
+++ b/src/app/features/register/register.interface.ts
@@ -10,8 +10,12 @@ interface AccountId {
 }
 
 export interface ApiResponseDTO {
-  status: string;
+  status: number;
   ok: boolean;
-  result: AccountId | null;
   message: string;
+  statusText?: string;
+  result?: AccountId;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  error?: any;
+  name?: string;
 }

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -27,9 +27,9 @@ export const valid = {
 export const errorMessages = {
   email: {
     required: 'Required field',
-    minlength: `Email must have a minimum of ${length.email.min} characters`,
-    maxLength: `Email must have a maximum of ${length.email.max} characters`,
-    pattern: "Email format must be valid, e.g: 'something@email.com'",
+    minlength: "Email format must be valid, e.g: 'a@b.ca'",
+    maxLength: `"Email format must be valid, e.g: 'not-this_long@email.com'"`,
+    pattern: "Email format must be valid, e.g: 'ab.cd@email.com'",
   },
   username: {
     required: 'Required field',

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -26,25 +26,25 @@ export const valid = {
 
 export const errorMessages = {
   email: {
-    required: 'required',
-    minlength: `minimum ${length.email.min} characters`,
-    maxLength: `maximum ${length.email.max} characters`,
-    pattern: "email format must be valid, e.g: 'something@email.com'",
+    required: 'Required field',
+    minlength: `Email must have a minimum of ${length.email.min} characters`,
+    maxLength: `Email must have a maximum of ${length.email.max} characters`,
+    pattern: "Email format must be valid, e.g: 'something@email.com'",
   },
   username: {
-    required: 'required',
-    minlength: `minimum ${length.username.min} characters`,
-    maxLength: `maximum ${length.username.max} characters`,
+    required: 'Required field',
+    minlength: `Username must have a minimum of ${length.username.min} characters`,
+    maxLength: `Username must have a maximum of ${length.username.max} characters`,
     pattern:
-      "username can only have numbers, dash (-) underscore (-), lowercased letter, (NO CAPITAL letter), e.g: 'user_name-2'",
+      "Username can only contain number, dash (-) underscore (-), lowercased letter, (NO CAPITAL letter), e.g: 'user_name-2'",
   },
   password: {
-    required: 'required',
-    minlength: `minimum ${length.password.min} characters`,
+    required: 'Required field',
+    minlength: `Password must have a minimum of ${length.password.min} characters`,
     pattern:
-      'password must have at least one number, one capital letter, and one lowercase letter, e.g.: Password123',
+      'Password must contain at least one number, one capital letter, and one lowercase letter, e.g.: paSsword123',
   },
   confirmPassword: {
-    required: 'required',
+    required: 'Required field',
   },
 };

--- a/src/proxy.conf.json
+++ b/src/proxy.conf.json
@@ -1,0 +1,8 @@
+{
+  "/api": {
+    "target": "http://localhost:3000",
+    "_target_": "http://127.0.0.1:3000",
+    "secure": false,
+    "logLevel": "debug"
+  }
+}


### PR DESCRIPTION
# Done

* Added angular proxy config for a call from localhost:4200 to backend's localhost:3000;
* Update email field's validation error message, to not specific;
* Removed username field from register form. We should make it really simple. In this register form, username will be auto-generated from email, i.e: `someone@email.com` => `someone-email-com`. User can update it later after registration in the setting/profile page;
* Added a script in the `package.json` to automate opening the `index.html` within `/coverage` folder to view which lines have not been covered by the unit tests;
* Added unit tests to cover the logic implementations for register form.